### PR TITLE
Deleting the meaningless `—rebase` option.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
         run: poetry run mike deploy --push --rebase "${GITHUB_REF##*/}"
 
       - name: Set default docs to ${LATEST_STABLE_BRANCH##*/}
-        run: poetry run mike set-default --push --rebase "${LATEST_STABLE_BRANCH##*/}"
+        run: poetry run mike set-default --push "${LATEST_STABLE_BRANCH##*/}"


### PR DESCRIPTION
As discussed in #2, the new `ci.yml` file must be adapted. 

Before we find a way to grab the latest doc version to set by default, let first avoid the rebasing on a branch that exists in the main repo, but not in this doc one.