### PR TITLE
Add link to a new dj-stripe guide

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -416,6 +416,7 @@
 <li><a href="https://www.saaspegasus.com/guides/django-stripe-integrate/">How to Create a Subscription SaaS Application with Django and Stripe - Sep 2021 - Django 3.2 - dj-stripe 2.4.3</a></li>
 <li><a href="https://ordinarycoders.com/blog/article/django-stripe-monthly-subscription">Using Django and Stripe for Monthly Subscriptions - May 4, 2021 Uses Stripe Elements</a></li>
 <li><a href="https://kartaca.com/en/django-stripe-integration-using-dj-stripe/">Django Stripe Integration with using dj-stripe - Jun 12, 2020</a></li>
+<li><a href="https://circumeo.io/blog/entry/start-charging-customers-with-django-and-dj-stripe/">Start Charging Customers with Django and DjStripe - Apr 22, 2024</a></li>
 </ul>
 <p><strong>Have a blog, video or online publication? Write about your dj-stripe tips and tricks, then send us a pull request with the link.</strong> </p>
 </div>


### PR DESCRIPTION
Hi, 

I've published [a guide to dj-stripe](https://circumeo.io/blog/entry/start-charging-customers-with-django-and-dj-stripe/) that I hope would be a worthwhile addition to the docs. 

Happy to answer any questions or make edits.